### PR TITLE
new option "root" - does the same that istanbul does when this is set:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .idea/
+node_modules

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Suppresses the output from Mocha and Istanbul
 
 Name of the output of the coverage folder
 
+##### _String_ `options.root` (default: `coverage`)
+
+The root path to look for files to instrument, defaults to ```.```. Can help to exclude directories that are not part of the code whose coverage should be checked.
+
 ##### _Number_ `options.check.statements` (default: `false`)
 
 Number of statements threshold to consider the coverage valid

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
         recursive: false,
         mask: false,
         coverageFolder: 'coverage',
+        root: false,
         check: {
           statements: false,
           lines: false,
@@ -35,6 +36,7 @@ module.exports = function (grunt) {
         }
       }),
       coverageFolder = path.join(process.cwd(), options.coverageFolder),
+      rootFolderForCoverage = options.root ? path.join(process.cwd(), options.root) : '.',
       done = this.async(),
       cmd = 'node',
       args = [];
@@ -43,7 +45,7 @@ module.exports = function (grunt) {
       var args = [], check = options.check;
 
       if (
-          check.statements !== false ||
+        check.statements !== false ||
           check.lines !== false ||
           check.functions !== false ||
           check.branches !== false
@@ -101,6 +103,11 @@ module.exports = function (grunt) {
 
     args.push(istanbulPath);              // node ./node_modules/istanbul/lib/cli.js
     args.push('--dir=' + coverageFolder); // node ./node_modules/istanbul/cli.js --dir=coverage
+    if (options.root) {
+      args.push('--root=' + rootFolderForCoverage);
+    }
+
+
     args.push('cover');                   // node ./node_modules/istanbul/lib/cli.js cover
     args.push(mochaPath);                 // node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha
     args.push('--');                      // node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --


### PR DESCRIPTION
restricts coverage to another set of files than "."
