### PR TITLE
Add Istanbul exclude patter for cover and MochaOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Options
 ##### _Boolean_ `options.slow` (default: `false`)
 ##### _String_ `options.grep` (default: `false`)
 ##### _Boolean_ `options.recursive` (default: `false`)
-
+##### _Array_ `options.mochaOptions` (default: `false`)
 Mochas parameters, check [http://visionmedia.github.io/mocha/#usage]
 
 ##### _Boolean_ `options.coverage` (default: `false`)
@@ -93,6 +93,10 @@ the file, containing the following callback `function(lcovcontent, done)`, and y
 ##### _Boolean_ `options.dryRun` (default: `false`)
 
 Spits out the command line that would be called, just to make sure everything is alright
+
+##### _Array_ `options.excludes` (default: `false`)
+
+Setting this exclude files from coverage report, check istanbul help cover
 
 ##### _String_ `options.mask` (default: `false`)
 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
           branches: false
         },
         excludes: false,
-        mochaOption : false
+        mochaOptions : false
       }),
       coverageFolder = path.join(process.cwd(), options.coverageFolder),
       rootFolderForCoverage = options.root ? path.join(process.cwd(), options.root) : '.',
@@ -187,8 +187,8 @@ module.exports = function (grunt) {
     if (options.mask) {
       masked = path.join(this.filesSrc[0], options.mask);
     }
-    if (options.mochaOption) {
-        options.mochaOption.forEach (function (opt){
+    if (options.mochaOptions) {
+        options.mochaOptions.forEach (function (opt){
             args.push(opt);
         });
     }


### PR DESCRIPTION
Sometimes it is required excludes some files from coverage reports, this option is available at istanbul cover option, so that I added to the code in order to used.

The mocha option allow to pass option such check-leaks to mocha allowing to take advantage of mocha parameter. This is advanced option.
