### PR TITLE
Keyword changed: grunt-plugin to gruntplugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "keywords"        : [
     "grunt",
-    "grunt-plugin",
+    "gruntplugin",
     "mocha",
     "istanbul",
     "test",


### PR DESCRIPTION
The official keyword for grunt plugins is gruntplugin, this is how it can be searched for and how it'll show up on gruntjs.org (it doesn't now).
