### PR TITLE
Use `process.execPath` instead of `node` executable.

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -2,7 +2,7 @@ module.exports = function (grunt){
   'use strict';
 
   var
-    cmd = 'node',
+    cmd = process.execPath,
     path = require('path'),
     mochaPath,
     istanbulPath;


### PR DESCRIPTION
When this task is run with a different node.js version than the "node"
executable in the path (or even worse, if no "node" is in the path), we have
a version mismatch, which leads to strange effects if we are dealing with
compiled modules.

So it is better to use `process.execPath` which should point to the
currently running version of node.