### PR TITLE
eliminate peerDependencies; closes #38

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function (grunt){
     done();
   });
 
-  grunt.loadNpmTasks('grunt-mocha-istanbul');
+  require('./tasks')(grunt);
 
   grunt.registerTask('default', ['mocha_istanbul']);
 };

--- a/README.md
+++ b/README.md
@@ -5,15 +5,25 @@
 grunt mocha istanbul task
 ==============
 
-[Mocha](http://visionmedia.github.com/mocha/) reporter to generate coverage report of [istanbul](http://gotwarlost.github.com/istanbul/) instrumented code, for grunt
+[Mocha](https://mochajs.org) reporter to generate coverage report of [istanbul](http://gotwarlost.github.com/istanbul/) instrumented code, for grunt
 This doesn't force you to use PhantomJS, or instrument code for server or client-side.
 
 Install
 ==============
 
-1. Install it using `npm install grunt-mocha-istanbul --save-dev`
-2. It needs `mocha`, `grunt` and `istanbul` to be installed locally on your project (aka, having them in your devDependencies)
-3. Call inside Gruntfile.js `grunt.loadNpmTasks('grunt-mocha-istanbul')`
+1. Install needed dependencies using: `npm install grunt mocha istanbul --save-dev`
+2. Install this package using: `npm install grunt-mocha-istanbul --save-dev`
+3. Call inside `Gruntfile.js`: `grunt.loadNpmTasks('grunt-mocha-istanbul')`
+
+Changes from 2.x
+==============
+
+Peer dependencies for `mocha` and `istanbul` have been removed.  You should `npm install` the following modules yourself:
+  
+- `mocha`
+- `istanbul` (or a compatible module; see `scriptPath` usage below)
+
+If using `npm` version < 3, you will need to install `grunt` as well.  
 
 Changes from 1.x
 ==============

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version"         : "2.4.0",
   "description"     : "Almost config-free Istanbul code coverage reporter for Mocha usage in Grunt",
   "peerDependencies": {
+    "grunt": "0.4.x"
+  },
+  "devDependencies": {
     "grunt": "0.4.x",
     "mocha": ">=1.x.x",
     "istanbul": "0.x.x"
@@ -10,6 +13,9 @@
   "repository"      : {
     "type": "git",
     "url" : "git://github.com/pocesar/grunt-mocha-istanbul.git"
+  },
+  "scripts": {
+    "test": "grunt"
   },
   "keywords"        : [
     "grunt",


### PR DESCRIPTION
- friendly error messages if packages are not installed
- packages checked upon task execution; not before
- `README.md` updated to reflect changes; assuming imminent bump to v3.0.0; fixed Mocha site URL

Tangential:

- modify `Gruntfile.js` to run the actual test(s), since I didn't want to send a PR w/o running them
- add a `test` target to `package.json`