### PR TITLE
fixing behaviour of file patterns in istanbul

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
                         lines: 1
                     },
                     require: ['test/*1.js'],
-                    excludes: ['test/excluded*.js'],
+                    excludes: ['test/excluded*.js', '**/other.js'],
                     mochaOptions: ['--bail', '--debug-brk'],
                     reporter: 'spec',
                     reportFormats: ['html','lcovonly']
@@ -24,21 +24,21 @@ module.exports = function (grunt) {
             babel: {
                 src: 'test/*.es6.js',
                 options: {
-                    nodeExec: require.resolve('.bin/babel-node.cmd'),
+                    nodeExec: require.resolve('.bin/babel-node'),
                     reportFormats: ['html'],
                     istanbulOptions: ['--verbose'],
                     root: 'es6',
-                    mochaOptions: ['--compilers', 'js:babel-register'],
+                    mochaOptions: ['--compilers', 'js:babel-register']
                 }
             },
             isparta: {
                 src: 'test/*.es5.js',
                 options: {
-                    nodeExec: require.resolve('.bin/babel-node.cmd'),
+                    nodeExec: require.resolve('.bin/babel-node'),
                     reportFormats: ['html'],
                     istanbulOptions: ['--verbose'],
                     root: 'es6',
-                    scriptPath: require.resolve('isparta/bin/isparta'),
+                    scriptPath: require.resolve('isparta/bin/isparta')
                 }
             }
         }

--- a/lib/src/other.js
+++ b/lib/src/other.js
@@ -1,0 +1,3 @@
+var some = require('./some');
+
+module.exports = function(a) { return some(3, a); };

--- a/lib/src/some.js
+++ b/lib/src/some.js
@@ -1,0 +1,1 @@
+module.exports = function (a,b) { return a + b; };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "grunt": "^1.0.1",
     "mocha": "^2.5.3",
     "istanbul": "^0.4.3",
-    "babel-cli": "^6.9.0"
+    "babel-cli": "^6.9.0",
+    "babel-preset-es2015": "^6.13.0",
+    "isparta": "^4.0.0"
   },
   "repository"      : {
     "type": "git",

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -186,10 +186,8 @@ module.exports = function (grunt) {
         if (options.excludes) {
             arrayOfStrings(options.excludes, 'options.excludes', function(options){
                 options.forEach(function (excluded) {
-                    grunt.file.expand({nonull: true}, excluded).forEach(function(expanded){
-                        args.push('-x');
-                        args.push(expanded);
-                    })
+                    args.push('-x');
+                    args.push(excluded);
                 });
             })
         }
@@ -197,10 +195,8 @@ module.exports = function (grunt) {
         if (options.includes) {
             arrayOfStrings(options.includes, 'options.includes', function(options){
                 options.forEach(function (included) {
-                    grunt.file.expand({nonull: true}, included).forEach(function(expanded){
-                        args.push('-i');
-                        args.push(expanded);
-                    })
+                    args.push('-i');
+                    args.push(included);
                 });
             })
         }

--- a/test/ignored_file.test.js
+++ b/test/ignored_file.test.js
@@ -1,0 +1,8 @@
+var other = require('../lib/src/other');
+
+describe('grunt mocha istanbul', function(){
+  it('should pass', function(){
+    console.log(other(4));
+    return other(4);
+  });
+});


### PR DESCRIPTION
the erronous new behaviour was introduced with version 5.0.0

the necessary changes are in file index.js - the other files contain corrections to the dependencies and illustrations of the behaviour: the new test must not show the coverage of file "other.js" in the coverage report.

questions? - feel free to ask

btw. version 5.0.\* break our builds (softwerkskammer/Agora) 
